### PR TITLE
Adapt config to spring-boot 2.4+ changes

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -14,7 +14,7 @@ server:
       # Minimum amount of worker threads.
       min-spare: 2 #default: 10
       # Maximum amount of worker threads.
-      max: 20 #defaul: 200
+      max: 20 #default: 200
 
 # Common configuration for all services. Override or add service specific config
 # properties on each <service-name>-service.yml file
@@ -95,7 +95,7 @@ spring:
   cloud:
     bus:
       enabled: true
-      id: ${server.instance-id} # use the same instance id for eureka (see service's' bootstrap.yml) and cloud-bus' rabbitmq instance id
+      id: ${info.instance-id} # use the same instance id for eureka (see service's' bootstrap.yml) and cloud-bus' rabbitmq instance id
       trace.enabled: false #switch on tracing of acks (default off).
     stream:
       bindings:
@@ -104,8 +104,8 @@ spring:
         springCloudBusInput:
           destination: gscatalog
   jackson:
-    default-property-inclusion: non_empty
-    serialization.indent_output: false #set to true if doing manual testing and want formatted output
+    default-property-inclusion: non-empty
+    serialization.indent-output: false #set to true if doing manual testing and want formatted output
 
 reactive.feign.cloud.enabled: true
 reactive.feign.hystrix.enabled: false
@@ -115,7 +115,7 @@ logging:
     root: WARN
     org.springframework: ERROR
     org.springframework.cloud.bus: INFO
-    org.springframework.retry: INFO
+    org.springframework.retry: info
     org.springframework.jdbc.support: INFO
     com.zaxxer.hikari.pool: OFF
     # geoserver roots
@@ -143,7 +143,7 @@ logging:
     org.springframework.cloud.config.server.environment.NativeEnvironmentRepository: WARN
 
 ---
-spring.profiles: local
+spring.config.activate.on-profile: local
 # provide environment variables that otherwise would be given by docker-compose.yml
 rabbitmq.host: localhost
 
@@ -151,22 +151,22 @@ jdbcconfig.url: jdbc:postgresql://localhost:5432/geoserver_config
 jdbcconfig.username: geoserver
 jdbcconfig.password: geo5erver
 ---
-spring.profiles: datadir
+spring.config.activate.on-profile: datadir
 backend.jdbcconfig: false
 backend.catalog: false
 backend.data-directory: true
 ---
-spring.profiles: jdbcconfig
+spring.config.activate.on-profile: jdbcconfig
 backend.jdbcconfig: true
 backend.catalog: false
 backend.data-directory: false
 ---
-spring.profiles: catalog
+spring.config.activate.on-profile: catalog
 backend.catalog: true
 backend.jdbcconfig: false
 backend.data-directory: false
 ---
-spring.profiles: debug
+spring.config.activate.on-profile: debug
 
 logging:
   level:

--- a/catalog-service.yml
+++ b/catalog-service.yml
@@ -29,5 +29,5 @@ geoserver:
 #  jackson.serialization.WRAP_ROOT_VALUE: false
 
 ---
-spring.profiles: local
+spring.config.activate.on-profile: local
 server.port: 9100

--- a/config-service.yml
+++ b/config-service.yml
@@ -1,3 +1,4 @@
+server.port: 8080
 spring:
   profiles:
     active: native #use native filesystem config by default instead of git. REVISIT.
@@ -7,3 +8,8 @@ logging:
   level:
     root: WARN
     org.springframework.cloud.config.server.environment.NativeEnvironmentRepository: WARN
+---
+spring.config.activate.on-profile: local
+server.port: 8888
+eureka.server.url: http://localhost:8761/eureka
+config.native.path: ./config

--- a/gateway-service.yml
+++ b/gateway-service.yml
@@ -96,11 +96,11 @@ spring:
 logging:
   level:
     root: WARN
-    com.netflix.discovery: WARN
-    com.netflix.eureka: WARN
+    com.netflix.discovery: INFO
+    com.netflix.eureka: INFO
     org.springframework.cloud.gateway: info
     reactor.netty: INFO
 ---
-spring.profiles: local
+spring.config.activate.on-profile: local
 server.port: 9000
     

--- a/restconfig-v1.yml
+++ b/restconfig-v1.yml
@@ -1,5 +1,5 @@
 geoserver:
   backend.catalog-service.enabled: ${backend.catalog:true}
 ---
-spring.profiles: local
+spring.config.activate.on-profile: local
 server.port: 9105

--- a/wcs-service.yml
+++ b/wcs-service.yml
@@ -1,6 +1,6 @@
 geoserver:
   backend.catalog-service.enabled: ${backend.catalog:true}
 ---
-spring.profiles: local
+spring.config.activate.on-profile: local
 server.port: 9103
   

--- a/web-ui.yml
+++ b/web-ui.yml
@@ -29,5 +29,5 @@ geoserver:
       resource-browser: true
       catalog-bulk-load: true
 ---
-spring.profiles: local
+spring.config.activate.on-profile: local
 server.port: 9106

--- a/wfs-service.yml
+++ b/wfs-service.yml
@@ -1,6 +1,6 @@
 geoserver:
   backend.catalog-service.enabled: ${backend.catalog:true}
 ---
-spring.profiles: local
+spring.config.activate.on-profile: local
 server.port: 9101
   

--- a/wms-service.yml
+++ b/wms-service.yml
@@ -1,5 +1,5 @@
 geoserver:
   backend.catalog-service.enabled: ${backend.catalog:true}
 ---
-spring.profiles: local
+spring.config.activate.on-profile: local
 server.port: 9102

--- a/wps-service.yml
+++ b/wps-service.yml
@@ -1,5 +1,5 @@
 geoserver:
   backend.catalog-service.enabled: ${backend.catalog:true}
 ---
-spring.profiles: local
+spring.config.activate.on-profile: local
 server.port: 9104


### PR DESCRIPTION
Pretty much boils down to changing
`spring.profiles: <profile>`
by
`spring.config.activate.on-profile: <profile>`

And moving the custom `server.instance-id` config property to `info.instance-id`