### PR TITLE
Adding vhost parameter to RabbitMQ config at Spring

### DIFF
--- a/geoserver_spring.yml
+++ b/geoserver_spring.yml
@@ -22,6 +22,7 @@ spring:
     port: ${rabbitmq.port:5672}
     username: ${rabbitmq.user:guest}
     password: ${rabbitmq.password:guest}
+    virtual-host: ${rabbitmq.vhost:}
   cloud:
     bus:
       enabled: true


### PR DESCRIPTION
Adding virtual-host parameter to Spring RabbitMQ configuration.
That allows to build RabbitMQ connection URL as follow:  

`amqp://<user>:<password>@<host>:<port>/<vhost>`

When the value is defined for an external configuration then vhost value will be used, and otherwise it's set to value gscloud.

In context of a case like this
https://github.com/camptocamp/helm-geoserver-cloud/blob/14b73dcff8908e19c41484d2160fcfa888e7330b/templates/_helpers.tpl#L140-L166

The vhost value is not used when an internal GSCloud RabbitMQ container is defined.