### PR TITLE
Handle response body compression only in the gateway (#118)

### DIFF
--- a/gateway.yml
+++ b/gateway.yml
@@ -45,6 +45,8 @@ server:
       - text/html
       - text/plain
       - text/xml
+      - text/css
+      - text/javascript
       - application/xml
       - application/json
       - application/geo+json

--- a/gateway.yml
+++ b/gateway.yml
@@ -41,6 +41,17 @@ server:
   forward-headers-strategy: framework
   compression:
     enabled: true
+    mime-types:
+      - text/html
+      - text/plain
+      - text/xml
+      - application/xml
+      - application/json
+      - application/geo+json
+      - application/gml+xml
+      - application/vnd.ogc.wms_xml
+      - application/vnd.ogc.se_xml
+    min-response-size: 2048
 
 spring:
   cloud:

--- a/geoserver.yml
+++ b/geoserver.yml
@@ -31,6 +31,10 @@ spring:
 # Common configuration for all services. Override or add service specific config
 # properties on each geoserver_<service>.yml file
 
+server:
+  compression:
+    enabled: false
+
 # GeoServer-Cloud common config properties
 geoserver:
   debug:


### PR DESCRIPTION
1. Disabled compression in all geoserver services via server.compression.enabled: false in geoserver.yml
2. Enabled compression at the gateway level in gateway.yml with relevant OGC mime-types
3. Related to geoserver/geoserver-cloud#118